### PR TITLE
Add ability to set `alias` on github configurations on catalog entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Changelog for the Cortex terraform provider.
 
 ## Unreleased
 
+* Add ability to set `alias` on github configurations on catalog entities
+
 ## 0.4.2
 * Fixes `cortex_scorecard` resource so that `rules` are a set. Order doesn't matter.
 

--- a/internal/cortex/catalog_entity_parser.go
+++ b/internal/cortex/catalog_entity_parser.go
@@ -280,6 +280,7 @@ func (c *CatalogEntityParser) interpolateGit(entity *CatalogEntityData, gitMap m
 		entity.Git.Github = CatalogEntityGitGithub{
 			Repository: MapFetchToString(githubMap, "repository"),
 			BasePath:   MapFetchToString(githubMap, "basepath"),
+			Alias:      MapFetchToString(githubMap, "alias"),
 		}
 	} else {
 		entity.Git.Github = CatalogEntityGitGithub{}

--- a/internal/cortex/integrations.go
+++ b/internal/cortex/integrations.go
@@ -435,6 +435,7 @@ func (o *CatalogEntityFireHydrantService) Enabled() bool {
 type CatalogEntityGitGithub struct {
 	Repository string `json:"repository" yaml:"repository"`
 	BasePath   string `json:"basepath,omitempty" yaml:"basepath,omitempty"`
+	Alias      string `json:"alias,omitempty" yaml:"alias,omitempty"`
 }
 
 func (o *CatalogEntityGitGithub) Enabled() bool {


### PR DESCRIPTION
This allows multi-configuration setups via terraform.