### PR TITLE
Add github alias to tf provider schema

### DIFF
--- a/docs/resources/catalog_entity.md
+++ b/docs/resources/catalog_entity.md
@@ -306,6 +306,7 @@ Required:
 
 Optional:
 
+- `alias` (String) GitHub alias. Only relevant if you've opted into multi-account support.
 - `base_path` (String) Base path if not /
 
 

--- a/internal/provider/catalog_entity_resource.go
+++ b/internal/provider/catalog_entity_resource.go
@@ -248,6 +248,10 @@ func (r *CatalogEntityResource) Schema(ctx context.Context, req resource.SchemaR
 								MarkdownDescription: "Base path if not /",
 								Optional:            true,
 							},
+							"alias": schema.StringAttribute{
+								MarkdownDescription: "GitHub alias. Only relevant if you've opted into multi-account support.",
+								Optional:            true,
+							},
 						},
 					},
 					"gitlab": schema.SingleNestedAttribute{

--- a/internal/provider/catalog_entity_resource_models.go
+++ b/internal/provider/catalog_entity_resource_models.go
@@ -830,12 +830,14 @@ func (o *CatalogEntityGitResourceModel) FromApiModel(ctx context.Context, diagno
 type CatalogEntityGithubResourceModel struct {
 	Repository types.String `tfsdk:"repository"`
 	BasePath   types.String `tfsdk:"base_path"`
+	Alias      types.String `tfsdk:"alias"`
 }
 
 func (o *CatalogEntityGithubResourceModel) AttrTypes() map[string]attr.Type {
 	return map[string]attr.Type{
 		"repository": types.StringType,
 		"base_path":  types.StringType,
+		"alias":      types.StringType,
 	}
 }
 
@@ -843,6 +845,7 @@ func (o *CatalogEntityGithubResourceModel) ToApiModel() cortex.CatalogEntityGitG
 	return cortex.CatalogEntityGitGithub{
 		Repository: o.Repository.ValueString(),
 		BasePath:   o.BasePath.ValueString(),
+		Alias:      o.Alias.ValueString(),
 	}
 }
 
@@ -854,9 +857,14 @@ func (o *CatalogEntityGithubResourceModel) FromApiModel(ctx context.Context, dia
 	if entity.BasePath == "" {
 		basePath = types.StringNull()
 	}
+	alias := types.StringValue(entity.Alias)
+	if entity.Alias == "" {
+		alias = types.StringNull()
+	}
 	ghm := CatalogEntityGithubResourceModel{
 		Repository: types.StringValue(entity.Repository),
 		BasePath:   basePath,
+		Alias:      alias,
 	}
 	obj, d := types.ObjectValueFrom(ctx, ghm.AttrTypes(), &ghm)
 	diagnostics.Append(d...)

--- a/internal/provider/catalog_entity_resource_test.go
+++ b/internal/provider/catalog_entity_resource_test.go
@@ -221,7 +221,6 @@ func TestAccCatalogEntityResourceComplete(t *testing.T) {
 					resource.TestCheckResourceAttr("cortex_catalog_entity.test", "links.0.url", "https://internal-docs.cortex.io/products-service"),
 
 					resource.TestCheckResourceAttr("cortex_catalog_entity.test", "git.github.repository", "cortexio/products-service"),
-					resource.TestCheckResourceAttr("cortex_catalog_entity.test", "git.gitlab.repository", "cortexio/products-service"),
 					resource.TestCheckResourceAttr("cortex_catalog_entity.test", "git.azure.project", "cortexio"),
 					resource.TestCheckResourceAttr("cortex_catalog_entity.test", "git.azure.repository", "cortexio/products-service"),
 					resource.TestCheckResourceAttr("cortex_catalog_entity.test", "git.bitbucket.repository", "cortexio/products-service"),
@@ -379,9 +378,6 @@ resource "cortex_catalog_entity" "test" {
 
   git = {
     github = {
-      repository = "cortexio/products-service"
-    }
-    gitlab = {
       repository = "cortexio/products-service"
     }
     azure = {


### PR DESCRIPTION
#4 forgot to set the alias on the provider side as well as the client side. This does so.

Also removes a gitlab stanza check in the acceptance test suite, that, due to changes in Cortex's API, can no longer be regression tested.